### PR TITLE
Quarter fix

### DIFF
--- a/src/components/FiscalDatePicker.tsx
+++ b/src/components/FiscalDatePicker.tsx
@@ -226,13 +226,10 @@ const FiscalDatePicker: React.FC<FiscalDatePickerProps> = ({ fiscalStartMonth = 
         return (
           <div
             key={year}
-            style={{
-              padding: "10px",
-              border: "1px solid #ccc",
-              backgroundColor: activeyear ? "#2c7d30" : "#f0f0f0",
-              color: activeyear ? "#fff" : "#000",
-            }}
-          >
+            className={`flex-1 px-8 py-2 text-m border ${activeyear
+              ? 'bg-blue-50 border-blue-500 text-blue-700'
+              : 'bg-white border-gray-300 text-gray-700 hover:bg-gray-50'
+              } ''`}>
             {year}
           </div>
         );
@@ -257,8 +254,8 @@ const FiscalDatePicker: React.FC<FiscalDatePickerProps> = ({ fiscalStartMonth = 
               onClick={() => toggleMonthSelection(month.date)}
               className={`
                 p-4 rounded-lg text-center transition-colors
-                ${isSelected ? 'bg-blue-100 hover:bg-blue-200' : 'hover:bg-gray-50'}
-                ${isCurrentMonth ? 'font-bold' : ''}
+            ${isSelected ? 'bg-blue-100 hover:bg-blue-200' : 'hover:bg-gray-50'}
+            ${isCurrentMonth ? 'font-bold' : ''}
               `}
             >
               <div className="text-sm text-gray-600">FY{month.fiscalYear}</div>

--- a/src/components/FiscalDatePicker.tsx
+++ b/src/components/FiscalDatePicker.tsx
@@ -117,6 +117,16 @@ const FiscalDatePicker: React.FC<FiscalDatePickerProps> = ({ fiscalStartMonth = 
     }
   };
 
+
+  const toggleYearSelection = (yearKey: string) => {
+    const isSelected = selectedYears.includes(yearKey);
+    if (isSelected) {
+      setSelectedYears(selectedYears.filter(m => m !== yearKey));
+    } else {
+      setSelectedYears([...selectedYears, yearKey]);
+    }
+  };
+
   const toggleMonthSelection = (date: Date) => {
     const monthKey = `${date.getFullYear()}-${date.getMonth()}`;
     const isSelected = selectedMonths.includes(monthKey);
@@ -160,6 +170,7 @@ const FiscalDatePicker: React.FC<FiscalDatePickerProps> = ({ fiscalStartMonth = 
     } else {
       setSelectedMonths([]);
       setSelectedQuarters([]);
+      setSelectedYears([]);
     }
   };
 
@@ -224,14 +235,15 @@ const FiscalDatePicker: React.FC<FiscalDatePickerProps> = ({ fiscalStartMonth = 
       {yearRange.map((year) => {
         const activeyear = selectedYears.includes(year.toString());
         return (
-          <div
+          <button
             key={year}
             className={`flex-1 px-8 py-2 text-m border ${activeyear
               ? 'bg-blue-50 border-blue-500 text-blue-700'
               : 'bg-white border-gray-300 text-gray-700 hover:bg-gray-50'
-              } ''`}>
+              } ''`}
+            onClick={() => toggleYearSelection(year.toString())}>
             {year}
-          </div>
+          </button>
         );
       })
       }

--- a/src/components/FiscalDatePicker.tsx
+++ b/src/components/FiscalDatePicker.tsx
@@ -219,7 +219,7 @@ const FiscalDatePicker: React.FC<FiscalDatePickerProps> = ({ fiscalStartMonth = 
   };
 
   const renderMultiYearRange = (yearRange: number[]) => {
-    return (<div className="year-number-container flex">
+    return (<div className="year-number-container flex" style={{ width: '100%', justifyContent: 'space-evenly' }}>
       {yearRange.map((year) => {
         const activeyear = true//activeYears.includes(year);
         return (
@@ -275,20 +275,22 @@ const FiscalDatePicker: React.FC<FiscalDatePickerProps> = ({ fiscalStartMonth = 
     <div className="w-full max-w-md mx-auto bg-white rounded-lg shadow-lg overflow-hidden">
       <div className="p-4 bg-gray-50 border-b flex items-center justify-between">
         <button
-          onClick={() => mode === 'date' ? changeMonth(-1) : mode === 'yearQuarterMonth' ? changeYear(-1) : changeYears(-1)}
+          onClick={() => mode === 'date' ? changeMonth(-1) : mode === 'yearQuarterMonth' || mode === 'yearMonth' ? changeYear(-1) : changeYears(-1)}
           className="p-2 hover:bg-gray-200 rounded-full transition-colors"
           aria-label={mode === 'date' ? "Previous month" : "Previous year"}
         >
           <ChevronLeft className="w-5 h-5" />
         </button>
-        <h2 className="text-lg font-semibold">
-          {mode === 'date'
-            ? currentDate.toLocaleString('default', { month: 'long', year: 'numeric' })
-            : mode === 'yearQuarterMonth' ? currentDate.getFullYear().toString() : renderMultiYearRange([2022, 2023, 2024, 2025])
-          }
-        </h2>
+        {mode === 'multiYearQuarterMonth' ? renderMultiYearRange([2023, 2024, 2025]) :
+          <h2 className="text-lg font-semibold">
+            {mode === 'date'
+              ? currentDate.toLocaleString('default', { month: 'long', year: 'numeric' })
+              : currentDate.getFullYear().toString()
+            }
+          </h2>}
+
         <button
-          onClick={() => mode === 'date' ? changeMonth(1) : mode === 'yearQuarterMonth' ? changeYear(1) : changeYears(1)}
+          onClick={() => mode === 'date' ? changeMonth(1) : mode === 'yearQuarterMonth' || mode === 'yearMonth' ? changeYear(1) : changeYears(1)}
           className="p-2 hover:bg-gray-200 rounded-full transition-colors"
           aria-label={mode === 'date' ? "Next month" : "Next year"}
         >

--- a/src/components/FiscalDatePicker.tsx
+++ b/src/components/FiscalDatePicker.tsx
@@ -13,6 +13,7 @@ const FiscalDatePicker: React.FC<FiscalDatePickerProps> = ({ fiscalStartMonth = 
   const [selectedMonths, setSelectedMonths] = useState<string[]>([]);
   const [selectedQuarters, setSelectedQuarters] = useState<string[]>([]);
   const [selectedYears, setSelectedYears] = useState<string[]>([currentDate.getFullYear().toString()]);
+  const [yearsRange, setYearsRange] = useState<number[]>([currentDate.getFullYear() - 1, currentDate.getFullYear(), currentDate.getFullYear() + 1]);
 
   const getDaysInMonth = (year: number, month: number) => {
     return new Date(year, month + 1, 0).getDate();
@@ -103,7 +104,7 @@ const FiscalDatePicker: React.FC<FiscalDatePickerProps> = ({ fiscalStartMonth = 
   };
 
   const changeYears = (increment: number) => {
-    console.log(increment)
+    setYearsRange([yearsRange[0] + increment, yearsRange[1] + increment, yearsRange[2] + increment]);
   };
 
   const toggleDateSelection = (date: Date) => {
@@ -120,7 +121,7 @@ const FiscalDatePicker: React.FC<FiscalDatePickerProps> = ({ fiscalStartMonth = 
 
   const toggleYearSelection = (yearKey: string) => {
     const isSelected = selectedYears.includes(yearKey);
-    if (isSelected) {
+    if (isSelected && selectedYears.length > 1) {
       setSelectedYears(selectedYears.filter(m => m !== yearKey));
     } else {
       setSelectedYears([...selectedYears, yearKey]);
@@ -171,6 +172,7 @@ const FiscalDatePicker: React.FC<FiscalDatePickerProps> = ({ fiscalStartMonth = 
       setSelectedMonths([]);
       setSelectedQuarters([]);
       setSelectedYears([]);
+      setYearsRange([currentDate.getFullYear() - 1, currentDate.getFullYear(), currentDate.getFullYear() + 1])
     }
   };
 
@@ -291,7 +293,7 @@ const FiscalDatePicker: React.FC<FiscalDatePickerProps> = ({ fiscalStartMonth = 
         >
           <ChevronLeft className="w-5 h-5" />
         </button>
-        {mode === 'multiYearQuarterMonth' ? renderMultiYearRange([currentDate.getFullYear() - 1, currentDate.getFullYear(), currentDate.getFullYear() + 1]) :
+        {mode === 'multiYearQuarterMonth' ? renderMultiYearRange(yearsRange) :
           <h2 className="text-lg font-semibold">
             {mode === 'date'
               ? currentDate.toLocaleString('default', { month: 'long', year: 'numeric' })

--- a/src/components/FiscalDatePicker.tsx
+++ b/src/components/FiscalDatePicker.tsx
@@ -12,6 +12,7 @@ const FiscalDatePicker: React.FC<FiscalDatePickerProps> = ({ fiscalStartMonth = 
   const [selectedDates, setSelectedDates] = useState<Date[]>([]);
   const [selectedMonths, setSelectedMonths] = useState<string[]>([]);
   const [selectedQuarters, setSelectedQuarters] = useState<string[]>([]);
+  const [selectedYears, setSelectedYears] = useState<string[]>([currentDate.getFullYear().toString()]);
 
   const getDaysInMonth = (year: number, month: number) => {
     return new Date(year, month + 1, 0).getDate();
@@ -221,7 +222,7 @@ const FiscalDatePicker: React.FC<FiscalDatePickerProps> = ({ fiscalStartMonth = 
   const renderMultiYearRange = (yearRange: number[]) => {
     return (<div className="year-number-container flex" style={{ width: '100%', justifyContent: 'space-evenly' }}>
       {yearRange.map((year) => {
-        const activeyear = true//activeYears.includes(year);
+        const activeyear = selectedYears.includes(year.toString());
         return (
           <div
             key={year}
@@ -281,7 +282,7 @@ const FiscalDatePicker: React.FC<FiscalDatePickerProps> = ({ fiscalStartMonth = 
         >
           <ChevronLeft className="w-5 h-5" />
         </button>
-        {mode === 'multiYearQuarterMonth' ? renderMultiYearRange([2023, 2024, 2025]) :
+        {mode === 'multiYearQuarterMonth' ? renderMultiYearRange([currentDate.getFullYear() - 1, currentDate.getFullYear(), currentDate.getFullYear() + 1]) :
           <h2 className="text-lg font-semibold">
             {mode === 'date'
               ? currentDate.toLocaleString('default', { month: 'long', year: 'numeric' })

--- a/src/components/FiscalDatePicker.tsx
+++ b/src/components/FiscalDatePicker.tsx
@@ -102,7 +102,7 @@ const FiscalDatePicker: React.FC<FiscalDatePickerProps> = ({ fiscalStartMonth = 
   };
 
   const changeYears = (increment: number) => {
-    setCurrentDate(new Date(currentDate.getFullYear() + (4 * increment), currentDate.getMonth(), 1));
+    console.log(increment)
   };
 
   const toggleDateSelection = (date: Date) => {
@@ -219,7 +219,7 @@ const FiscalDatePicker: React.FC<FiscalDatePickerProps> = ({ fiscalStartMonth = 
   };
 
   const renderMultiYearRange = (yearRange: number[]) => {
-    return (<div className="year-number-container">
+    return (<div className="year-number-container flex">
       {yearRange.map((year) => {
         const activeyear = true//activeYears.includes(year);
         return (

--- a/src/components/FiscalQuarterPicker.tsx
+++ b/src/components/FiscalQuarterPicker.tsx
@@ -41,7 +41,7 @@ export const FiscalQuarterPicker: React.FC<FiscalQuarterPickerProps> = ({
 
     // Toggle quarter selection
     onQuarterSelect(quarterKey);
-    let dateArr: Array<Date> = [];
+    const dateArr: Array<Date> = [];
     quarterMonths.forEach(month => {
       const date = new Date(year, month, 1);
       dateArr.push(date)


### PR DESCRIPTION
### **PR Type**
enhancement, bug fix


___

### **Description**
- Enhanced the `FiscalDatePicker` component by adding state management for selected years and years range, allowing for more flexible year selection.
- Implemented a new function `toggleYearSelection` to manage year selection logic.
- Updated the UI and logic for rendering a multi-year range, improving user interaction.
- Refactored navigation logic to accommodate different modes, fixing issues with year and month transitions.
- In `FiscalQuarterPicker`, refactored the quarter date array to be a constant, improving code clarity.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FiscalDatePicker.tsx</strong><dd><code>Enhance year selection and navigation logic in FiscalDatePicker</code></dd></summary>
<hr>

src/components/FiscalDatePicker.tsx

<li>Added state management for selected years and years range.<br> <li> Implemented <code>toggleYearSelection</code> function for year selection.<br> <li> Updated styles and logic for rendering multi-year range.<br> <li> Enhanced navigation logic for different modes.<br>


</details>


  </td>
  <td><a href="https://github.com/visualbis/date-picker/pull/1/files#diff-c626d3a4b85f2c2f66cc9883524ac33a8e8a6b39731f43634ad7d281f5c37134">+36/-22</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>FiscalQuarterPicker.tsx</strong><dd><code>Refactor quarter date array to constant in FiscalQuarterPicker</code></dd></summary>
<hr>

src/components/FiscalQuarterPicker.tsx

- Changed `dateArr` to a constant for quarter date management.



</details>


  </td>
  <td><a href="https://github.com/visualbis/date-picker/pull/1/files#diff-71c865f7eee5bf37dd7f290e5c0820761bdeda032fb4a5dbdb2c810e0fe12c94">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information